### PR TITLE
Add a server method mechanism for getting data also.

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -11,37 +11,48 @@ var internals = {
 };
 
 
+internals.generateHapiInfo = function(server) {
+
+    var payload = {
+        server: {
+            node: process.version,
+            hapi: server._sources[0].server.version
+        },
+        plugins: []
+    };
+
+    for (var i = 0, il = server._sources.length; i < il; ++i) {
+        var source = server._sources[i];
+        if (!source._registrations) {
+            continue;
+        }
+        var registrations = Object.keys(source._registrations);
+
+        for (var j = 0, ij = registrations.length; j < ij; ++j) {
+            var pluginKey = registrations[j];
+            var plugin = source._registrations[pluginKey];
+            payload.plugins.push({ name: plugin.name, version: plugin.version });
+        }
+    }
+
+    return payload;
+};
+
+
 exports.register = function (server, options, next) {
 
     var validation = Joi.validate(options, internals.schema);
     Hoek.assert(validation.error === null, 'Invalid option(s)');
     options = validation.value;
 
+    server.method('generateHapiInfo', internals.generateHapiInfo, { callback: false });
+
     server.route({
         method: 'GET',
         path: options.path,
         handler: function (request, reply) {
 
-            var payload = {
-                server: {
-                    node: process.version,
-                    hapi: server._sources[0].server.version
-                },
-                plugins: []
-            };
-            for (var i = 0, il = server._sources.length; i < il; ++i) {
-                var source = server._sources[i];
-                if (!source._registrations) {
-                    continue;
-                }
-                var registrations = Object.keys(source._registrations);
-
-                for (var j = 0, ij = registrations.length; j < ij; ++j) {
-                    var pluginKey = registrations[j];
-                    var plugin = source._registrations[pluginKey];
-                    payload.plugins.push({ name: plugin.name, version: plugin.version });
-                }
-            }
+            var payload = request.server.methods.generateHapiInfo(server);
             return reply(payload);
         }
     });

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hapi-info",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "",
   "main": "lib/index.js",
   "scripts": {
@@ -9,6 +9,9 @@
   "author": "",
   "license": "ISC",
   "author": "Daniel Bretoi",
+  "contributors": [
+    "Brian Delahunty <brian@briandela.com>"
+  ],
   "keywords": [
     "hapi",
     "plugin",


### PR DESCRIPTION
I wanted to be able to also get the information that hapi-inof was returing by the route, through a server method so I could include it with other system status (e.g. database, etc.) I have in an existing status route.

This change pulls the code which generates `payload` to a synchronous server-method so I can be called as a server method and also continues to works as is today.