### PR TITLE
Update to work with hapi 11.x.x-12.x.x. Use lab's built in linting.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,4 @@
+language: node_js
+node_js:
+  - 5
+  - 4

--- a/README.md
+++ b/README.md
@@ -1,7 +1,10 @@
+[![Build Status](https://travis-ci.org/danielb2/hapi-info.svg?branch=master)](https://travis-ci.org/danielb2/hapi-info)
+
 # hapi-info
 
 `hapi-info` is a plugin to display information about the hapi server and the
 plugins it's running.
+
 
 ### Usage
 
@@ -30,25 +33,25 @@ The following options are available:
 
 ``` javascript
 {
-    server: {
-        node: 'v0.10.39',
-        hapi: '8.8.1',
-        host: 'sanji.local',
-        port: 0,
-        uri: 'http://sanji.local'
+    "server":{
+        "node":"v4.2.6",
+        "hapi":"11.1.4",
+        "host":"inis",
+        "port":0,
+        "uri":"http://inis"
     },
-    plugins: [
+    "plugins":[
         {
-            name: 'hapi-info',
-            version: '1.0.0'
+            "name":"hapi-info",
+            "version":"2.0.0"
         },
         {
-            name: 'blah',
-            version: '1.2.3'
+            "name":"blah",
+            "version":"1.2.3"
         },
         {
-            name: 'main',
-            version: '0.1.1'
+            "name":"main",
+            "version":"0.1.1"
         }
     ]
 }

--- a/lib/index.js
+++ b/lib/index.js
@@ -1,14 +1,16 @@
+'use strict';
+
 // Load modules
 
-var Hoek = require('hoek');
-var Joi = require('joi');
+const Hoek = require('hoek');
+const Joi = require('joi');
 
-var Pkg = require('../package.json');
+const Pkg = require('../package.json');
 
 
 // Declare internals
 
-var internals = {
+const internals = {
     schema: {
         path: Joi.string().optional().default('/hapi-info').allow(null)
     }
@@ -17,7 +19,7 @@ var internals = {
 
 exports.register = function (server, options, next) {
 
-    var validation = Joi.validate(options, internals.schema);
+    const validation = Joi.validate(options, internals.schema);
     Hoek.assert(validation.error === null, 'Invalid option(s)');
     options = validation.value;
 
@@ -29,7 +31,7 @@ exports.register = function (server, options, next) {
             path: options.path,
             handler: function (request, reply) {
 
-                var payload = server.plugins[Pkg.name].info();
+                const payload = server.plugins[Pkg.name].info();
                 return reply(payload);
             }
         });
@@ -44,12 +46,12 @@ exports.register.attributes = {
 };
 
 
-internals.generateHapiInfo = function() {
+internals.generateHapiInfo = function () {
 
-    var payload = {
+    const payload = {
         server: {
             node: process.version,
-            hapi: this._sources[0].server.version,
+            hapi: this.version,
             host: this.info.host,
             port: this.info.port,
             uri: this.info.uri
@@ -57,16 +59,13 @@ internals.generateHapiInfo = function() {
         plugins: []
     };
 
-    for (var i = 0, il = this._sources.length; i < il; ++i) {
-        var source = this._sources[i];
-        if (!source._registrations) {
-            continue;
-        }
-        var registrations = Object.keys(source._registrations);
+    for (let i = 0; i < this.connections.length; ++i) {
+        const connection = this.connections[i];
+        const registrations = Object.keys(connection.registrations);
 
-        for (var j = 0, ij = registrations.length; j < ij; ++j) {
-            var pluginKey = registrations[j];
-            var plugin = source._registrations[pluginKey];
+        for (let j = 0; j < registrations.length; ++j) {
+            const pluginKey = registrations[j];
+            const plugin = connection.registrations[pluginKey];
             payload.plugins.push({ name: plugin.name, version: plugin.version });
         }
     }

--- a/package.json
+++ b/package.json
@@ -1,10 +1,10 @@
 {
   "name": "hapi-info",
-  "version": "1.1.0",
+  "version": "2.0.0",
   "description": "",
   "main": "lib/index.js",
   "scripts": {
-    "test": "lab -a code -v -t 100"
+    "test": "lab -a code -v -t 100 -L"
   },
   "repository": {
     "type": "git",
@@ -18,13 +18,15 @@
     "hapi-plugin"
   ],
   "devDependencies": {
-    "code": "1.x.x",
-    "glue": "2.x.x",
-    "hapi": "8.x.x",
-    "lab": "5.x.x"
+    "code": "2.x.x",
+    "glue": "3.x.x",
+    "lab": "8.x.x"
   },
   "dependencies": {
-    "hoek": "2.x.x",
-    "joi": "6.x.x"
+    "hoek": "3.x.x",
+    "joi": "7.x.x"
+  },
+  "peerDependencies": {
+    "hapi": "11.x.x - 12.x.x"
   }
 }

--- a/test/index.js
+++ b/test/index.js
@@ -1,35 +1,33 @@
+'use strict';
 // Load modules
 
-var Code = require('code');
-var Glue = require('glue');
-var Hapi = require('hapi');
-var Lab = require('lab');
+const Code = require('code');
+const Glue = require('glue');
+const Lab = require('lab');
 
 
 // Test shortcuts
 
-var lab = exports.lab = Lab.script();
-var expect = Code.expect;
-var describe = lab.describe;
-var it = lab.test;
+const lab = exports.lab = Lab.script();
+const expect = Code.expect;
+const describe = lab.describe;
+const it = lab.test;
 
 
-var internals = {};
+const internals = {};
 
 
 internals.prepareServer = function (options, callback) {
 
-    var server = new Hapi.Server();
-
-    var manifest = {
-        plugins: [
-            { '../': options },
-            { './plugins/blah.js': null },
-            { './plugins/main.js': null }
+    const manifest = {
+        registrations: [
+            { plugin: { register: '../', options: options } },
+            { plugin: { register:'./plugins/blah.js', options: null } },
+            { plugin: { register: './plugins/main.js', options: null } }
         ]
     };
 
-    Glue.compose(manifest, { relativeTo: __dirname }, function (err, server) {
+    Glue.compose(manifest, { relativeTo: __dirname }, (err, server) => {
 
         expect(err).to.not.exist();
         return callback(err, server);
@@ -39,82 +37,83 @@ internals.prepareServer = function (options, callback) {
 
 internals.makeResult = function (server) {
 
-    var result = {
+    const result = {
         server: {
             node: process.version,
-            hapi: '8.8.1',
+            hapi: server.version,
             host: server.info.host,
             port: server.info.port,
             uri: server.info.uri
         },
-        plugins: [{
-            name: 'hapi-info',
-            version: require('./../package.json').version
-        },
-        {
-            name: 'blah',
-            version: '1.2.3'
-        },
-        {
-            name: 'main',
-            version: '0.1.1'
-        }]
+        plugins: [
+            {
+                name: 'hapi-info',
+                version: require('./../package.json').version
+            },
+            {
+                name: 'blah',
+                version: '1.2.3'
+            },
+            {
+                name: 'main',
+                version: '0.1.1'
+            }
+        ]
     };
 
     return result;
 };
 
+describe('routes', () => {
 
-describe('routes', function () {
+    it('prints plugin and server information', (done) => {
 
-    it('prints plugin and server information', function (done) {
+        internals.prepareServer({}, (err, server) => {
 
-        internals.prepareServer({}, function (err, server) {
+            server.inject('/hapi-info', (res) => {
 
-            server.inject('/hapi-info', function (res) {
-
-                var result = internals.makeResult(server);
+                const result = internals.makeResult(server);
                 expect(res.result).to.deep.equal(result);
-                done();
+                done(err);
             });
         });
     });
 
-    it('prints plugin and server to a different path', function (done) {
+    it('prints plugin and server to a different path', (done) => {
 
-        internals.prepareServer({ path: '/foo' }, function (err, server) {
+        internals.prepareServer({ path: '/foo' }, (err, server) => {
 
-            server.inject('/foo', function (res) {
+            server.inject('/foo', (res) => {
 
-                var result = internals.makeResult(server);
+                const result = internals.makeResult(server);
                 expect(res.result).to.deep.equal(result);
-                done();
+                done(err);
             });
         });
     });
 
-    it('prints plugin and server info using expose', function (done) {
+    it('prints plugin and server info using expose', (done) => {
 
-        internals.prepareServer({ path: '/foo' }, function (err, server) {
+        internals.prepareServer({ path: '/foo' }, (err, server) => {
 
-            var info = server.plugins['hapi-info'].info();
-            var result = internals.makeResult(server);
+            const info = server.plugins['hapi-info'].info();
+            const result = internals.makeResult(server);
             expect(info).to.deep.equal(result);
-            done();
+            done(err);
         });
     });
 
-    it('setting path to null doesnt create route, but still exposes info data', function (done) {
+    it('setting path to null doesnt create route, but still exposes info data', (done) => {
 
-        internals.prepareServer({ path: null }, function (err, server) {
+        internals.prepareServer({ path: null }, (err, server) => {
 
-            server.inject('/hapi-info', function (res) {
+            server.inject('/hapi-info', (res) => {
 
                 expect(res.statusCode).to.equal(404);
-                var info = server.plugins['hapi-info'].info();
-                var result = internals.makeResult(server);
+                const info = server.plugins['hapi-info'].info();
+                const result = internals.makeResult(server);
                 expect(info).to.deep.equal(result);
-                done();
+                done(err);
             });
         });
     });

--- a/test/plugins/blah.js
+++ b/test/plugins/blah.js
@@ -1,3 +1,5 @@
+'use strict';
+
 exports.register = function (plugin, options, next) {
 
     return next();

--- a/test/plugins/main.js
+++ b/test/plugins/main.js
@@ -1,3 +1,5 @@
+'use strict';
+
 exports.register = function (plugin, options, next) {
 
     return next();


### PR DESCRIPTION
- Update to work with hapi 11.x.x-12.x.x
- Use lab's built in linting
- Update the code to style to match the lab linting style (which is based on the hapi style)
- Added a `.travis.yml` file to build as node
- Updated the `README.md` with the travis build badge

@danielb2 Let me know if you would like something in the `README.md` mentioning the compatible hapi versions.