### PR TITLE
Updating peerDependencies to allow for Hapi 13.x.x

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,6 +27,6 @@
     "joi": "7.x.x"
   },
   "peerDependencies": {
-    "hapi": "11.x.x - 12.x.x"
+    "hapi": "11.x.x - 13.x.x"
   }
 }


### PR DESCRIPTION
I am not sure if there is something that is breaking in Hapi 13.x, however from my testing it seemed to work. 